### PR TITLE
gh-7: to enable CORS and accept options request

### DIFF
--- a/api/create.go
+++ b/api/create.go
@@ -55,7 +55,11 @@ func Hello(w http.ResponseWriter, req *http.Request) {
 }
 
 func CreateService(w http.ResponseWriter, req *http.Request) {
-	if req.Method != "POST" {
+	enableCors(&w)
+	if (*req).Method == "OPTIONS" {
+		return
+	}
+	if (*req).Method != "POST" {
 		http.Error(w, "Invalid Method", http.StatusMethodNotAllowed)
 		return
 	}
@@ -158,4 +162,10 @@ func connectService(s service) error {
 	}
 	log.Printf("INFO: DNS record created for %s ", s.UserID)
 	return nil
+}
+
+func enableCors(w *http.ResponseWriter) {
+	// TODO: to remove the wildcard and control it to specific host
+	(*w).Header().Set("Access-Control-Allow-Origin", "*")
+	(*w).Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
 }


### PR DESCRIPTION
Tested on my local machine and its working fine.

visi@visis-MacBook-Pro ~ % curl -X OPTIONS http://localhost:3001/createservice -i
HTTP/1.1 200 OK
Access-Control-Allow-Methods: POST, OPTIONS
Access-Control-Allow-Origin: *
Date: Thu, 15 Jul 2021 06:43:54 GMT
Content-Length: 0