### PR TITLE
Prevent empty auth tokens from returning 500

### DIFF
--- a/api/list_cluster.go
+++ b/api/list_cluster.go
@@ -16,7 +16,8 @@ func ListCluster(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "Invalid Method", http.StatusMethodNotAllowed)
 		return
 	}
-	userId, err := validateToken(*req)
+	authHeader := req.Header.Get("Authorization")
+	userId, err := validateToken(authHeader)
 	log.Println("listcluster")
 	if err != nil {
 		log.Printf("error validating token %v", err)


### PR DESCRIPTION
This handles cases where the auth token is an empty string more gracefully (returns an error instead of crashing the server).

It also changes the signature of  `validateToken` to accept only the Authorization header instead of the complete request.

Closes #50 