### PR TITLE
receive db username and password from user request

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -118,17 +118,19 @@ func createDockerComposeFile(absolutepath string, s service) error {
 	// TODO: not sure is there a better way to pass data to template
 	// A lot of this data is redundant. Already available in Service struct
 	data := struct {
-		UserID       string
-		Architecture string
-		Type         string
-		Port         int
-		Secret       string
+		UserID           string
+		Architecture     string
+		Type             string
+		Port             int
+		PostgresUsername string
+		PostgresPassword string
 	}{
 		s.UserID,
 		s.Architecture,
 		s.Db.Type,
 		s.Db.Port,
-		"replaceme",
+		s.Db.Username,
+		s.Db.Password,
 	}
 	err = templ.Execute(f, data)
 	if err != nil {

--- a/api/templates/docker-compose-template.yml
+++ b/api/templates/docker-compose-template.yml
@@ -7,7 +7,8 @@ services:
     ports:
       - "{{ .Port }}:5432"
     environment:
-      POSTGRES_PASSWORD: {{ .Secret }}
+      POSTGRES_USER: {{ .PostgresUsername }}
+      POSTGRES_PASSWORD: {{ .PostgresPassword }}
     volumes:
       - data-volume-{{ .UserID }}:/var/lib/postgresql/data
 

--- a/config.yaml
+++ b/config.yaml
@@ -3,5 +3,5 @@ common:
     5432, 5433, 5434, 5435, 5436, 5437
   ]
   architecture: amd64
-  projectDir: /Users/visi/spinup/local
+  projectDir: /home/michael/lab/org/spinup/spinup
 


### PR DESCRIPTION
This adds support for accepting the database credentials from the frontend. The credentials are stored in the sqlite database as @viggy28 mentioned in our earlier discussion. I went with this approach as I thought it makes sense for users to want to pick a database/password when creating a service from the dashboard for instance.

To try it out though, you'd need to:
- remove any existing docker volume that exists for a postgres container created by spinup (else docker just reuses the volume and the new credentials won't apply - I think).
- remove the sqlite file containing clusterInfo table (else, the newly added columns won't exist in the table).

Regarding point two above, I think we could introduce some sort of migration structure to manage the tables at this point. I know of [golang-migrate/migrate](https://github.com/golang-migrate/migrate) but I don't know how solid sqlite support is yet.