### PR TITLE
Add endpoint for listing the details of only a specific cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,34 @@ postgres=# \dt
 #### Error Response:
     Code: 500 INTERNALSERVER ERROR
 
+### Get service
+`/cluster?cluster_id=<CLUSTER_ID>` - Fetches specific details of a service or cluster
+#### Method:
+`GET`
+#### Authentication Header
+`Bearer <GITHUB_TOKEN>`
+#### Path Parameters
+- `cluster_id=[String]`: ID of the cluster to be retrieved.
+#### Responses
+200:
+```json
+{
+    "data": {
+        "cluster_id": "a130e42a09f4\n",
+        "id": 2,
+        "name": "localtest",
+        "port": 5432,
+        "username": "localtest"
+    }
+}
+```
+404:
+```json
+{
+    "message": "no cluster found with matching id"
+}
+```
+
 ### JWT
 - URL
 

--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+// respond converts its data parameter to JSON and send it as an HTTP response
+func respond(statusCode int, w http.ResponseWriter, data interface{}) {
+	if statusCode == http.StatusNoContent {
+		w.WriteHeader(statusCode)
+		return
+	}
+
+	// Convert the response value to JSON.
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		log.Println(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	if _, err := w.Write(jsonData); err != nil {
+		log.Println(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}

--- a/api/create.go
+++ b/api/create.go
@@ -219,7 +219,7 @@ func lastContainerID() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(output), nil
+	return strings.TrimSuffix(string(output), "\n"), nil
 }
 
 func updateSqliteDB(path string, dbName string, data service) {

--- a/api/list_cluster.go
+++ b/api/list_cluster.go
@@ -137,7 +137,7 @@ func getClusterFromDb(clusterId string) (clusterInfo, error) {
 	}
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
-		log.Fatal(err)
+		return ci, err
 	}
 	defer db.Close()
 

--- a/api/list_cluster.go
+++ b/api/list_cluster.go
@@ -38,9 +38,11 @@ func ListCluster(w http.ResponseWriter, req *http.Request) {
 }
 
 type clusterInfo struct {
-	ClusterID string
-	Name      string
-	Port      int
+	ID        int    `json:"id"`
+	ClusterID string `json:"cluster_id"`
+	Name      string `json:"name"`
+	Port      int    `json:"port"`
+	Username  string `json:"username"`
 }
 
 func ReadClusterInfo(path, dbName string) []clusterInfo {
@@ -71,4 +73,81 @@ func ReadClusterInfo(path, dbName string) []clusterInfo {
 	}
 	fmt.Println(clusterIds)
 	return clusterInfos
+}
+
+func GetCluster(w http.ResponseWriter, r *http.Request) {
+	if (*r).Method != "GET" {
+		respond(http.StatusMethodNotAllowed, w, map[string]interface{}{
+			"message": "method not allowed",
+		})
+		return
+	}
+	// todo (idoqo): move auth stuff to a "middleware"
+	authHeader := r.Header.Get("Authorization")
+	var err error
+	config.Cfg.UserID, err = config.ValidateToken(authHeader)
+	if err != nil {
+		log.Printf("error validating token %v", err)
+		respond(http.StatusInternalServerError, w, map[string]interface{}{
+			"message": "could not validate token",
+		})
+		return
+	}
+
+	clusterId := r.URL.Query().Get("cluster_id")
+	if clusterId == "" {
+		respond(http.StatusBadRequest, w, map[string]interface{}{
+			"message": "cluster_id not present",
+		})
+		return
+	}
+
+	ci, err := getClusterFromDb(clusterId)
+	if errors.Is(err, fs.ErrNotExist) {
+		log.Println(err)
+		respond(http.StatusInternalServerError, w, map[string]interface{}{
+			"message": "sqlite database was not found",
+		})
+	}
+
+	if err == sql.ErrNoRows {
+		respond(http.StatusNotFound, w, map[string]interface{}{
+			"message": "no cluster found with matching id",
+		})
+		return
+	} else if err != nil {
+		log.Println(err)
+		respond(http.StatusInternalServerError, w, map[string]interface{}{
+			"message": "could not get cluster details",
+		})
+		return
+	}
+
+	respond(http.StatusOK, w, map[string]interface{}{
+		"data": ci,
+	})
+}
+
+func getClusterFromDb(clusterId string) (clusterInfo, error) {
+	var ci clusterInfo
+	path := config.Cfg.Common.ProjectDir + "/" + config.Cfg.UserID
+	dsn := path + "/" + config.Cfg.UserID + ".db"
+	if _, err := os.Stat(dsn); errors.Is(err, fs.ErrNotExist) {
+		return ci, err
+	}
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	query := `SELECT id, clusterId, name, username, port FROM clusterInfo WHERE clusterId = ? LIMIT 1`
+	err = db.QueryRow(query, clusterId).Scan(
+		&ci.ID,
+		&ci.ClusterID,
+		&ci.Name,
+		&ci.Username,
+		&ci.Port,
+	)
+	return ci, err
 }

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 	mux.HandleFunc("/jwtdecode", api.JWTDecode)
 	mux.HandleFunc("/streamlogs", api.StreamLogs)
 	mux.HandleFunc("/listcluster", api.ListCluster)
+	mux.HandleFunc("/cluster", api.GetCluster)
 	mux.HandleFunc("/metrics", metrics.HandleMetrics)
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"https://app.spinup.host", "http://localhost:3000"},


### PR DESCRIPTION
This adds a `/cluster` endpoint to fetch details of a specific cluster. It also fixes an extra newline character that is added to the containerID (extra newline exists because we read the container from stdout using the exec package).

### Testing
The endpoint will return a 404 for existing clusters - because of the trailing newline issue. To try this out, create a new cluster and note the cluster_id, then send a `GET` request to `/cluster?cluster_id=<CLUSTER_ID>`.

Also, this doesn't return the cluster password as part of its response - I'm wondering if "seeing" the password should be a separate endpoint call or if we should make it part of this.