### PR TITLE
Fix import paths

### DIFF
--- a/api/create.go
+++ b/api/create.go
@@ -15,13 +15,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spinup-host/internal/dockerservice"
-
 	"github.com/docker/docker/client"
 	"github.com/robfig/cron/v3"
-	"github.com/spinup-host/backup"
-	"github.com/spinup-host/config"
-	"github.com/spinup-host/misc"
+	"github.com/spinup-host/spinup/backup"
+	"github.com/spinup-host/spinup/config"
+	"github.com/spinup-host/spinup/internal/dockerservice"
+	"github.com/spinup-host/spinup/misc"
 	_ "modernc.org/sqlite"
 )
 

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/spinup-host/templates"
+	"github.com/spinup-host/spinup/templates"
 )
 
 //TODO: vicky find how to keep the templates/* outside of the api. ie need to figure how to do relative path.

--- a/api/jwt.go
+++ b/api/jwt.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt"
-	"github.com/spinup-host/config"
+	"github.com/spinup-host/spinup/config"
 )
 
 func stringToJWT(text string) (string, error) {

--- a/api/list_cluster.go
+++ b/api/list_cluster.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/spinup-host/config"
+	"github.com/spinup-host/spinup/config"
 
 	_ "modernc.org/sqlite"
 )

--- a/api/userauth.go
+++ b/api/userauth.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/spinup-host/config"
+	"github.com/spinup-host/spinup/config"
 )
 
 type user struct {

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -2,7 +2,7 @@ package backup
 
 import (
 	"fmt"
-	"github.com/spinup-host/internal/dockerservice"
+	"github.com/spinup-host/spinup/internal/dockerservice"
 	"log"
 
 	"github.com/docker/docker/client"

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -13,9 +13,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/spinup-host/api"
-	"github.com/spinup-host/config"
-	"github.com/spinup-host/metrics"
+	"github.com/spinup-host/spinup/api"
+	"github.com/spinup-host/spinup/config"
+	"github.com/spinup-host/spinup/metrics"
 
 	"github.com/golang-jwt/jwt"
 	"github.com/rs/cors"

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"embed"
 	"log"
 
-	"github.com/spinup-host/internal/cmd"
+	"github.com/spinup-host/spinup/internal/cmd"
 )
 
 var (

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -8,8 +8,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/spinup-host/api"
-	"github.com/spinup-host/config"
+	"github.com/spinup-host/spinup/api"
+	"github.com/spinup-host/spinup/config"
 )
 
 func HandleMetrics(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Turned out we had some wrongly written imports e.g:
```
github.com/spinup-host/internal/dockerservice
```
which causes `go mod tidy` to fail with the following:
```
github.com/spinup-host/spinup/internal/cmd imports
        github.com/spinup-host/metrics: cannot find module providing package github.com/spinup-host/metrics: module github.com/spinup-host/metrics: git ls-remote -q origin in /home/michael/go/pkg/mod/cache/vcs/4977b821078266a578311537cb42956a8549cc67685a55f79f4184bb55842c1f: exit status 128:
        ERROR: Repository not found.
        fatal: Could not read from remote repository.
        
        Please make sure you have the correct access rights
        and the repository exists.
```

I'm surprised that this is just becoming a problem though.