### PR TITLE
viggy/gh-100: To avoid sqlite conn open; fix package path

### DIFF
--- a/api/create.go
+++ b/api/create.go
@@ -6,15 +6,15 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"path/filepath"
 	"strconv"
 
-	"github.com/spinup-host/internal/dockerservice"
-	"github.com/spinup-host/internal/metastore"
-	"github.com/spinup-host/internal/monitoring"
-	"github.com/spinup-host/internal/postgres"
-	"github.com/spinup-host/misc"
-
-	"github.com/spinup-host/config"
+	"github.com/spinup-host/spinup/config"
+	"github.com/spinup-host/spinup/internal/dockerservice"
+	"github.com/spinup-host/spinup/internal/metastore"
+	"github.com/spinup-host/spinup/internal/monitoring"
+	"github.com/spinup-host/spinup/internal/postgres"
+	"github.com/spinup-host/spinup/misc"
 	_ "modernc.org/sqlite"
 )
 
@@ -98,7 +98,7 @@ func CreateService(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "Error getting container id", 500)
 		return
 	}
-	path := config.Cfg.Common.ProjectDir + "/" + s.UserID + "/" + s.UserID + ".db"
+	path := filepath.Join(config.Cfg.Common.ProjectDir, "metastore.db")
 	db, err := metastore.NewDb(path)
 	if err != nil {
 		misc.ErrorResponse(w, "error accessing sqlite database", 500)

--- a/api/jwt.go
+++ b/api/jwt.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt"
-	"github.com/spinup-host/config"
+	"github.com/spinup-host/spinup/config"
 )
 
 func stringToJWT(text string) (string, error) {

--- a/api/userauth.go
+++ b/api/userauth.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/spinup-host/config"
+	"github.com/spinup-host/spinup/config"
 )
 
 type user struct {

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/docker/docker/api/types"
@@ -19,11 +20,11 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
 	"github.com/robfig/cron/v3"
-	"github.com/spinup-host/config"
-	"github.com/spinup-host/internal/dockerservice"
-	"github.com/spinup-host/internal/metastore"
-	"github.com/spinup-host/internal/postgres"
-	"github.com/spinup-host/misc"
+	"github.com/spinup-host/spinup/config"
+	"github.com/spinup-host/spinup/internal/dockerservice"
+	"github.com/spinup-host/spinup/internal/metastore"
+	"github.com/spinup-host/spinup/internal/postgres"
+	"github.com/spinup-host/spinup/misc"
 )
 
 const PREFIXBACKUPCONTAINER = "spinup-postgres-backup-"
@@ -72,7 +73,7 @@ func CreateBackup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	path := config.Cfg.Common.ProjectDir + "/" + s.UserID + "/" + s.UserID + ".db"
+	path := filepath.Join(config.Cfg.Common.ProjectDir, "metastore.db")
 	db, err := metastore.NewDb(path)
 	if err != nil {
 		misc.ErrorResponse(w, "error accessing database", 500)

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -13,10 +13,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/spinup-host/api"
-	"github.com/spinup-host/config"
-	"github.com/spinup-host/internal/backup"
-	"github.com/spinup-host/metrics"
+	"github.com/spinup-host/spinup/api"
+	"github.com/spinup-host/spinup/config"
+	"github.com/spinup-host/spinup/internal/backup"
+	"github.com/spinup-host/spinup/metrics"
 
 	"github.com/golang-jwt/jwt"
 	"github.com/rs/cors"
@@ -34,6 +34,14 @@ var (
 )
 
 func apiHandler() http.Handler {
+	ch, err := api.NewClusterHandler()
+	if err != nil {
+		log.Fatal("unable to create NewClusterHandler")
+	}
+	mh, err := metrics.NewMetricsHandler()
+	if err != nil {
+		log.Fatal("unable to create NewClusterHandler")
+	}
 	rand.Seed(time.Now().UnixNano())
 	mux := http.NewServeMux()
 	mux.HandleFunc("/hello", api.Hello)
@@ -43,11 +51,10 @@ func apiHandler() http.Handler {
 	mux.HandleFunc("/jwt", api.JWT)
 	mux.HandleFunc("/jwtdecode", api.JWTDecode)
 	mux.HandleFunc("/streamlogs", api.StreamLogs)
-	mux.HandleFunc("/listcluster", api.ListCluster)
+	mux.HandleFunc("/listcluster", ch.ListCluster)
 	mux.HandleFunc("/cluster", api.GetCluster)
-	mux.HandleFunc("/metrics", metrics.HandleMetrics)
+	mux.HandleFunc("/metrics", mh.ServeHTTP)
 	mux.HandleFunc("/createbackup", backup.CreateBackup)
-	//mux.HandleFunc("/pghba", backup.UpdatePghba)
 	mux.HandleFunc("/altauth", api.AltAuth)
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"https://app.spinup.host", "http://localhost:3000"},

--- a/internal/dockerservice/dockerservice.go
+++ b/internal/dockerservice/dockerservice.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/spinup-host/misc"
+	"github.com/spinup-host/spinup/misc"
 )
 
 type Docker struct {

--- a/internal/metastore/metastore.go
+++ b/internal/metastore/metastore.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/spinup-host/config"
+	"github.com/spinup-host/spinup/config"
 )
 
 type Db struct {

--- a/internal/monitoring/monitoring.go
+++ b/internal/monitoring/monitoring.go
@@ -6,9 +6,9 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
-	"github.com/spinup-host/internal/dockerservice"
-	"github.com/spinup-host/internal/postgres"
-	"github.com/spinup-host/misc"
+	"github.com/spinup-host/spinup/internal/dockerservice"
+	"github.com/spinup-host/spinup/internal/postgres"
+	"github.com/spinup-host/spinup/misc"
 )
 
 // Target represents a postgres host (target) for monitoring

--- a/internal/postgres/postgres.go
+++ b/internal/postgres/postgres.go
@@ -12,8 +12,8 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/go-connections/nat"
-	"github.com/spinup-host/internal/dockerservice"
-	"github.com/spinup-host/misc"
+	"github.com/spinup-host/spinup/internal/dockerservice"
+	"github.com/spinup-host/spinup/misc"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/spinup-host/internal/cmd"
+	"github.com/spinup-host/spinup/internal/cmd"
 )
 
 var (

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -2,33 +2,51 @@ package metrics
 
 import (
 	"fmt"
+	"log"
 	"net/http"
+	"path/filepath"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/spinup-host/config"
-	"github.com/spinup-host/internal/metastore"
+	"github.com/spinup-host/spinup/config"
+	"github.com/spinup-host/spinup/internal/metastore"
 )
 
-func HandleMetrics(w http.ResponseWriter, req *http.Request) {
-	if (*req).Method != "GET" {
+type MetricsHandler struct {
+	Db metastore.Db
+}
+
+func NewMetricsHandler() (MetricsHandler, error) {
+	path := filepath.Join(config.Cfg.Common.ProjectDir, "metastore.db")
+	log.Println("remove path:", path)
+	db, err := metastore.NewDb(path)
+	if err != nil {
+		return MetricsHandler{}, err
+	}
+	return MetricsHandler{
+		Db: db,
+	}, nil
+}
+
+func (m *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if (*r).Method != "GET" {
 		http.Error(w, "Invalid Method", http.StatusMethodNotAllowed)
 		return
 	}
-	/* 	authHeader := req.Header.Get("Authorization")
-	   	apiKeyHeader := req.Header.Get("x-api-key")
-	   	var err error
-	   	config.Cfg.UserID, err = config.ValidateUser(authHeader, apiKeyHeader)
-	   	if err != nil {
-	   		log.Printf(err.Error())
-	   		http.Error(w, "error validating user", http.StatusUnauthorized)
-	   		return
-	   	} */
+	authHeader := r.Header.Get("Authorization")
+	apiKeyHeader := r.Header.Get("x-api-key")
+	var err error
+	config.Cfg.UserID, err = config.ValidateUser(authHeader, apiKeyHeader)
+	if err != nil {
+		log.Printf(err.Error())
+		http.Error(w, "error validating user", http.StatusUnauthorized)
+		return
+	}
 	errCh := make(chan error, 1)
-	recordMetrics(errCh)
-	promhttp.Handler().ServeHTTP(w, req)
+	recordMetrics(m.Db, errCh)
+	promhttp.Handler().ServeHTTP(w, r)
 }
 
 var (
@@ -38,17 +56,7 @@ var (
 	})
 )
 
-var db metastore.Db
-var err error
-
-func recordMetrics(errCh chan error) {
-	dbPath := config.Cfg.Common.ProjectDir + "/" + config.Cfg.UserID + "/" + config.Cfg.UserID + ".db"
-	if db.Client == nil {
-		db, err = metastore.NewDb(dbPath)
-		if err != nil {
-			return
-		}
-	}
+func recordMetrics(db metastore.Db, errCh chan error) {
 	go func() {
 		for {
 			time.Sleep(2 * time.Second)

--- a/misc/misc.go
+++ b/misc/misc.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spinup-host/config"
+	"github.com/spinup-host/spinup/config"
 )
 
 func minMax(array []int) (int, int) {


### PR DESCRIPTION
1. Fixes import path. Moved the module path from module github.com/spinup-host to module github.com/spinup-host/spinup. Hence all the packages need to be updated
2. Changes the location of sqlite db from $projectDir/$user to $projectDir
3. Avoids open connection to SQLite every time when an API endpoint is hit by converting the handlerFunc to the handler and initializing the handler. 