### PR TITLE
Preserve existing configuration during update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/cors v1.8.0
-	github.com/rs/zerolog v1.25.0
 	github.com/spf13/cobra v1.2.1
+	golang.org/x/tools v0.1.5 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	modernc.org/sqlite v1.14.7
 )

--- a/go.sum
+++ b/go.sum
@@ -630,9 +630,6 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.8.0 h1:P2KMzcFwrPoSjkF1WLRPsp3UMLyql8L4v9hQpVeK5so=
 github.com/rs/cors v1.8.0/go.mod h1:EBwu+T5AvHOcXwvZIkQFjUN6s8Czyqw12GL/Y0tUyRM=
-github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
-github.com/rs/zerolog v1.25.0 h1:Rj7XygbUHKUlDPcVdoLyR91fJBsduXj5fRxyqIQj/II=
-github.com/rs/zerolog v1.25.0/go.mod h1:7KHcEGe0QZPOm2IE4Kpb5rTh6n1h2hIgS5OOnu1rUaI=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=

--- a/scripts/install-spinup.sh
+++ b/scripts/install-spinup.sh
@@ -19,6 +19,7 @@ if [ -z "$CLIENT_SECRET" ]; then
 fi
 
 SPINUP_DIR=${SPINUP_DIR:-"${HOME}/.local/spinup"}
+echo "Fetching latest Spinup version..."
 SPINUP_VERSION=$(curl --silent "https://api.github.com/repos/spinup-host/spinup/releases" | jq -r 'first | .tag_name')
 
 OS=$(go env GOOS)
@@ -56,19 +57,26 @@ rm -rf ${SPINUP_DIR}/spinup-dash
 cp -a -R ${SPINUP_TMP_DIR}/spinup-dash/build ${SPINUP_DIR}/spinup-dash
 
 cd ${SPINUP_DIR}
-cat >config.yaml <<-EOF
-common:
-  ports: [
-    5432, 5433, 5434, 5435, 5436, 5437
-  ]
-  db_metric_ports: [
-    55432, 55433, 55434, 55435, 55436, 55437
-  ]
-  architecture: amd64
-  projectDir: ${SPINUP_DIR}
-  client_id: ${CLIENT_ID}
-  client_secret: ${CLIENT_SECRET}
+# preserve existing config file, or create a new one if none exists
+
+CONFIG_FILE="${SPINUP_DIR}/config.yaml"
+if [[ -f "$CONFIG_FILE" ]]; then
+  echo "Found existing configuration file at ${CONFIG_FILE}."
+else
+  cat >config.yaml <<-EOF
+  common:
+    ports: [
+      5432, 5433, 5434, 5435, 5436, 5437
+    ]
+    db_metric_ports: [
+      55432, 55433, 55434, 55435, 55436, 55437
+    ]
+    architecture: amd64
+    projectDir: ${SPINUP_DIR}
+    client_id: ${CLIENT_ID}
+    client_secret: ${CLIENT_SECRET}
 EOF
+fi
 
 openssl genrsa -out ${SPINUP_DIR}/app.rsa 4096
 openssl rsa -in ${SPINUP_DIR}/app.rsa -pubout > ${SPINUP_DIR}/app.rsa.pub


### PR DESCRIPTION
At the moment, we overwrite the configuration file in the Spinup install directory when installing a new update (via `install-spinup.sh`). This can be annoying as users will then have to update it again with the appropriate credentials.

This PR checks if the file exists, and only creates a new config file if it doesn't.