### PR TITLE
Fix API response for created services

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -71,11 +71,6 @@ type Destination struct {
 	ApiKeyID     string
 	ApiKeySecret string
 }
-type serviceResponse struct {
-	HostName    string
-	Port        int
-	ContainerID string
-}
 
 type ClusterInfo struct {
 	ID         int    `json:"id"`


### PR DESCRIPTION
Somewhere around [this commit](https://github.com/spinup-host/spinup/commit/585d955905e2d69c1d7f68f5736b5695b0c61191#diff-b7df59a310c87ed0ee42d20487805876ff8b7c62db47652db41de0dde690744a), we broke the API response when new postgres services are created and started returning an empty response.

This adds back the response, and remove the monitoring block, since that is now improved in #114 