### PR TITLE
account for duplicate network names

### DIFF
--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -100,7 +101,11 @@ func startCmd() *cobra.Command {
 			ctx := context.TODO()
 			_, err = dockerClient.CreateNetwork(ctx, config.DefaultNetworkName, types.NetworkCreate{CheckDuplicate: true})
 			if err != nil {
-				utils.Logger.Fatal("unable to create docker network", zap.Error(err))
+				if errors.Is(err, dockerservice.ErrDuplicateNetwork) {
+					utils.Logger.Fatal(fmt.Sprintf("found multiple docker networks with name: '%s', remove them and restart Spinup.", config.DefaultNetworkName))
+				} else {
+					utils.Logger.Fatal("unable to create docker network", zap.Error(err))
+				}
 			}
 
 			if config.Cfg.Common.Monitoring {

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -98,7 +98,7 @@ func startCmd() *cobra.Command {
 				utils.Logger.Error("could not create docker client", zap.Error(err))
 			}
 			ctx := context.TODO()
-			_, err = dockerClient.CreateNetwork(ctx, config.DefaultNetworkName, types.NetworkCreate{})
+			_, err = dockerClient.CreateNetwork(ctx, config.DefaultNetworkName, types.NetworkCreate{CheckDuplicate: true})
 			if err != nil {
 				utils.Logger.Fatal("unable to create docker network", zap.Error(err))
 			}


### PR DESCRIPTION
Turns out docker allows multiple networks to have the same name by default and we missed that possiblilty. For now, what we do is:
- if network does not exist, we create it.
- if only one network exists with the same name, we re-use it.
- if multiple networks exist with the same name, we return an error and ask the user to clean them up and restart.