### PR TITLE
properly start container if it exists

### DIFF
--- a/api/create.go
+++ b/api/create.go
@@ -162,7 +162,6 @@ func (c ClusterHandler) CreateService(w http.ResponseWriter, req *http.Request) 
 			// todo: find a way to send "info" messages to the client without making them an error
 			log.Println("monitoring services are not running, Spinup will start them in the background")
 		}
-		return
 	}
 
 	serviceResponse := config.ClusterInfo{

--- a/internal/dockerservice/container.go
+++ b/internal/dockerservice/container.go
@@ -51,7 +51,7 @@ func NewContainer(name string, config container.Config, hostConfig container.Hos
 	}
 }
 
-// Start starts a docker container. If the base image doesn't exist locally, we attempt to pull it from
+// Start creates and starts a docker container. If the base image doesn't exist locally, we attempt to pull it from
 // the docker registry.
 func (c *Container) Start(ctx context.Context, d Docker) (container.ContainerCreateCreatedBody, error) {
 	body := container.ContainerCreateCreatedBody{}
@@ -89,6 +89,16 @@ func (c *Container) Start(ctx context.Context, d Docker) (container.ContainerCre
 
 	log.Printf("started %s container with ID: %s", c.Name, c.ID)
 	return body, nil
+}
+
+// StartExisting starts a docker container. Unlike Start(), this method only concerns itself with starting a container
+// and will not try to create it or pull the image.
+func (c *Container) StartExisting(ctx context.Context, d Docker) error {
+	err := d.Cli.ContainerStart(ctx, c.ID, c.Options)
+	if err != nil {
+		return errors.Wrapf(err, "unable to start container %s", c.ID)
+	}
+	return nil
 }
 
 // imageExistsLocally returns a boolean indicating if an image with the

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -85,6 +85,10 @@ func (r *Runtime) BootstrapServices() error {
 		// if the container exists, we only update the host address without over-writing the existing prometheus config
 		r.dockerHostAddr = promContainer.NetworkConfig.EndpointsConfig[config.DefaultNetworkName].Gateway
 		r.logger.Info("reusing existing prometheus container")
+		err = promContainer.StartExisting(ctx, r.dockerClient)
+		if err != nil {
+			return errors.Wrap(err, "failed to start existing prometheus container")
+		}
 	}
 
 	pgExporterContainer, err = r.dockerClient.GetContainer(ctx, PgExporterContainerName)
@@ -102,6 +106,10 @@ func (r *Runtime) BootstrapServices() error {
 		}
 	} else {
 		r.logger.Info("reusing existing postgres_exporter container")
+		err = pgExporterContainer.StartExisting(ctx, r.dockerClient)
+		if err != nil {
+			return errors.Wrap(err, "failed to start existing pg_exporter container")
+		}
 	}
 
 	r.logger.Info(fmt.Sprintf("using docker host address :%s", r.dockerHostAddr))


### PR DESCRIPTION
There's a bug with monitoring where we skip starting containers if they exist (but not running). This resolves that and properly reports any error that occur.