### PR TITLE
make monitoring independent of requests

### DIFF
--- a/api/create.go
+++ b/api/create.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -143,18 +144,19 @@ func (c ClusterHandler) CreateService(w http.ResponseWriter, req *http.Request) 
 		} else {
 			// this might take more time especially if the image doesn't exist locally, so we wrap it in a goroutine
 			go func() {
+				ctx := context.Background()
 				dockerClient, err := dockerservice.NewDocker()
 				if err != nil {
 					log.Printf("error creating client %v", err)
 					return
 				}
 				c.monitor = monitor.NewRuntime(dockerClient, utils.Logger)
-				if err := c.monitor.BootstrapServices(); err != nil {
+				if err := c.monitor.BootstrapServices(ctx); err != nil {
 					log.Println(err)
 				} else {
 					log.Println("started monitoring services")
 				}
-				if err = c.monitor.AddTarget(req.Context(), target); err != nil {
+				if err = c.monitor.AddTarget(ctx, target); err != nil {
 					log.Printf("ERROR: setting up monitoring for service: %v", err)
 				}
 			}()

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -110,7 +110,7 @@ func startCmd() *cobra.Command {
 
 			if config.Cfg.Common.Monitoring {
 				monitorRuntime = monitor.NewRuntime(dockerClient, utils.Logger)
-				if err := monitorRuntime.BootstrapServices(); err != nil {
+				if err := monitorRuntime.BootstrapServices(ctx); err != nil {
 					utils.Logger.Error("could not start monitoring services", zap.Error(err))
 				} else {
 					utils.Logger.Info("started spinup monitoring services")

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -36,11 +36,10 @@ type Target struct {
 
 // BootstrapServices starts up prometheus and exporter services in docker containers
 // todo: clean up started services on SIGKILL or SIGTERM
-func (r *Runtime) BootstrapServices() error {
+func (r *Runtime) BootstrapServices(ctx context.Context) error {
 	var err error
 	var promContainer *dockerservice.Container
 	var pgExporterContainer *dockerservice.Container
-	ctx := context.TODO()
 
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
When monitoring is not enabled in user config, but they try to enable it while creating a new service, we create a new goroutine to set up the monitoring services. Functions in the new goroutine use the request context (which causes issues e.g in the screenshot, as the request has already been responded to and closed).

This fixes that by using a new background context in the goroutine to make it independent of the request.

![image](https://user-images.githubusercontent.com/10512379/174425086-02f7ea71-45f3-4825-af06-17a7a112a731.png)
