### PR TITLE
Set postgres exporter instance on startup 

### DIFF
--- a/api/userauth.go
+++ b/api/userauth.go
@@ -138,12 +138,16 @@ func AltAuth(w http.ResponseWriter, r *http.Request) {
 	}
 	apiKeyHeader := r.Header.Get("x-api-key")
 	_, err := config.ValidateUser("", apiKeyHeader)
+
+	response := map[string]string{}
+	var code int
 	if err != nil {
-		respond(http.StatusUnauthorized, w, map[string]string{
-			"message": err.Error(),
-		})
-		return
+		response["message"] = err.Error()
+		code = http.StatusUnauthorized
+	} else {
+		response["message"] = "valid API key"
+		code = http.StatusOK
 	}
-	w.Write([]byte("Valid Api Key"))
-	w.WriteHeader(http.StatusOK)
+	respond(code, w, response)
+	return
 }

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -166,7 +166,7 @@ func startCmd() *cobra.Command {
 							if !os.IsNotExist(err) {
 								utils.Logger.Error("could not find asset", zap.Error(err))
 							}
-							// Requested file does not exist so we return the default (resolves to index.html)
+							// Requested file does not exist, we return the default (resolves to index.html)
 							r.URL.Path = "/"
 						}
 					}

--- a/internal/dockerservice/container_test.go
+++ b/internal/dockerservice/container_test.go
@@ -1,0 +1,52 @@
+package dockerservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStart(t *testing.T) {
+	testID := uuid.New().String()
+	ctx := context.Background()
+	dc, err := newDockerTest(ctx, testID)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = dc.cleanup(t)
+		if err != nil {
+			t.Logf("failed to clean up test containers" + err.Error())
+		}
+	})
+
+	t.Run("duplicate container name", func(t *testing.T) {
+		c1 := NewContainer(
+			"test_container",
+			container.Config{Image: testImage},
+			container.HostConfig{},
+			network.NetworkingConfig{
+				EndpointsConfig: map[string]*network.EndpointSettings{
+					dc.NetworkName: {},
+				},
+			},
+		)
+		_, err = c1.Start(ctx, dc.Docker)
+		assert.NoError(t, err)
+
+		c2 := NewContainer(
+			"test_container",
+			container.Config{Image: testImage},
+			container.HostConfig{}, network.NetworkingConfig{
+				EndpointsConfig: map[string]*network.EndpointSettings{
+					dc.NetworkName: {},
+				},
+			})
+		_, err = c2.Start(ctx, dc.Docker)
+		assert.ErrorIs(t, err, ErrDuplicateContainerName)
+	})
+}

--- a/internal/dockerservice/dockerservice.go
+++ b/internal/dockerservice/dockerservice.go
@@ -27,11 +27,11 @@ func NewDocker(networkName string, opts ...client.Opt) (Docker, error) {
 	if err != nil {
 		fmt.Printf("error creating client %v", err)
 	}
-	//TODO: Check. Does this initialize and assign
 	return Docker{NetworkName: networkName, Cli: cli}, nil
 }
 
 var ErrDuplicateNetwork = errors.New("duplicate networks found with given name")
+var ErrDuplicateContainerName = errors.New("a container already exists with the given name")
 
 // GetContainer returns a docker container with the provided name (if any exists).
 // if no match exists, it returns a nil container and a nil error.

--- a/internal/dockerservice/dockerservice_test.go
+++ b/internal/dockerservice/dockerservice_test.go
@@ -2,57 +2,107 @@ package dockerservice
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"log"
-	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/multierr"
 )
 
-var docker Docker
+var testImage = "tianon/true"
 
-func TestMain(m *testing.M) {
-	cli, err := client.NewClientWithOpts()
-	if err != nil {
-		fmt.Printf("error creating client %v", err)
-	}
-	docker = Docker{Cli: cli}
-	//TODO: (viggy) we should create some customer spinup images for testing purpose instead of using docker registry postgres images
-	imagesToRemove := []string{"postgres:14-alpine", "postgres:13-alpine"}
-	removeImageHelper(imagesToRemove)
-	exitVal := m.Run()
-	removeImageHelper(imagesToRemove)
-	os.Exit(exitVal)
+// dockerTest is a package-specific wrapper around Docker to be used for tests without creating an import cycle
+type dockerTest struct {
+	Docker
 }
 
-func removeImageHelper(imagesToRemove []string) {
-	for _, imageToRemove := range imagesToRemove {
-		err := removeDockerImage(docker, imageToRemove)
-		if err != nil {
-			log.Printf("INFO: error removing docker image %s %v \n", imageToRemove, err)
+func newDockerTest(ctx context.Context, networkName string) (dockerTest, error) {
+	dc, err := NewDocker(networkName)
+	if err != nil {
+		return dockerTest{}, err
+	}
+
+	_, err = dc.CreateNetwork(ctx)
+	if err != nil {
+		return dockerTest{}, errors.Wrap(err, "create network")
+	}
+	return dockerTest{
+		Docker: dc,
+	}, nil
+}
+
+// cleanup removes all containers and volumes in the docker network, and removes the network itself.
+func (dt dockerTest) cleanup(t *testing.T) error {
+	t.Helper()
+	ctx := context.Background()
+	filter := filters.NewArgs()
+	filter.Add("network", dt.NetworkName)
+
+	containers, err := dt.Cli.ContainerList(ctx, types.ContainerListOptions{All: true, Filters: filter})
+	if err != nil {
+		return errors.Wrap(err, "list containers")
+	}
+
+	var cleanupErr error
+	for _, c := range containers {
+		t.Log(c.Names)
+		stopTimeout := 1 * time.Second
+		if err = dt.Cli.ContainerStop(ctx, c.ID, &stopTimeout); err != nil {
+			if strings.Contains(err.Error(), "No such container") {
+				continue
+			}
+			cleanupErr = multierr.Append(cleanupErr, errors.Wrap(err, "stop container"))
+		}
+		if err = dt.Cli.ContainerRemove(ctx, c.ID, types.ContainerRemoveOptions{}); err != nil {
+			if strings.Contains(err.Error(), "No such container") {
+				continue
+			}
+			cleanupErr = multierr.Append(cleanupErr, errors.Wrap(err, "remove container"))
+		}
+
+		// cleanup its volumes
+		for _, mount := range c.Mounts {
+			if mount.Type == "volume" {
+				if err = dt.Cli.VolumeRemove(ctx, mount.Name, true); err != nil {
+					cleanupErr = multierr.Append(cleanupErr, errors.Wrap(err, "remove volume"))
+				}
+			}
 		}
 	}
-}
 
-func removeDockerImage(d Docker, image string) error {
-	_, err := d.Cli.ImageRemove(context.Background(), image, types.ImageRemoveOptions{
-		Force: true,
-	})
-	return err
+	if err = dt.Cli.NetworkRemove(ctx, dt.NetworkName); err != nil {
+		cleanupErr = multierr.Append(cleanupErr, errors.Wrap(err, "remove network"))
+	}
+	return nil
 }
 
 func Test_imageExistsLocally(t *testing.T) {
+	ctx := context.Background()
+	testID := uuid.New().String()
+	dc, err := newDockerTest(ctx, testID)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = dc.cleanup(t)
+		if err != nil {
+			t.Log("failed to clean test containers", err.Error())
+		}
+	})
+
 	data := []struct {
 		name                        string
 		image                       string
 		pullImageFromDockerRegistry bool
 		expected                    bool
 	}{
-		{"image exist", "alpine", true, true},
+		{"image exist", "tianon/true", true, true},
 		{"image doesnot exist", "imageDoesnotExist:notag", false, false},
 	}
 	for _, d := range data {
@@ -62,11 +112,11 @@ func Test_imageExistsLocally(t *testing.T) {
 				// INFO: not sure what's the best way to make sure an image exists locally. Hence pulling it before testing imageExistsLocally.
 				// Perhaps we could move this to TestMain() which means we need to define a type for struct - not sure its that the right way to do
 				// postgres:9.6-alpine image will be pulled since its fairly small. It could be any image.
-				if err := pullImageFromDockerRegistry(docker, d.image); err != nil {
+				if err := pullImageFromDockerRegistry(dc.Docker, d.image); err != nil {
 					t.Errorf("error setting up imageExistsLocally() for test data %+v", d)
 				}
 			}
-			actual, err := imageExistsLocally(context.Background(), docker, d.image)
+			actual, err := imageExistsLocally(context.Background(), dc.Docker, d.image)
 			if err != nil {
 				t.Errorf("error testing imageExistsLocally() for test data %+v", d)
 
@@ -79,17 +129,26 @@ func Test_imageExistsLocally(t *testing.T) {
 }
 
 func Test_pullImageFromDockerRegistry(t *testing.T) {
+	ctx := context.Background()
+	testID := uuid.New().String()
+	dc, err := newDockerTest(ctx, testID)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		assert.NoError(t, dc.cleanup(t))
+	})
+
 	data := []struct {
 		name     string
 		image    string
 		expected error
 	}{
-		{"image exist", "postgres:13-alpine", nil},
+		{"image exist", "tianon/true", nil},
 		{"image doesnot exist", "imageDoesnotExistInRegistry:notag", errors.New("unable to pull docker image")},
 	}
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
-			actual := pullImageFromDockerRegistry(docker, d.image)
+			actual := pullImageFromDockerRegistry(dc.Docker, d.image)
 			if actual != d.expected {
 				if !strings.Contains(actual.Error(), d.expected.Error()) {
 					t.Errorf("incorrect result: actual %t , expected %t", actual, d.expected)

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -92,13 +92,13 @@ func (r *Runtime) BootstrapServices(ctx context.Context) error {
 				return errors.Wrap(err, "failed to update prometheus config")
 			}
 		} else {
-			// if the container exists, we only update the host address without over-writing the existing prometheus config
-			r.dockerHostAddr = promContainer.NetworkConfig.EndpointsConfig[r.dockerClient.NetworkName].Gateway
 			r.logger.Info("reusing existing prometheus container")
 			err = promContainer.StartExisting(ctx, r.dockerClient)
 			if err != nil {
 				return errors.Wrap(err, "failed to start existing prometheus container")
 			}
+			// if the container exists, we only update the host address without over-writing the existing prometheus config
+			r.dockerHostAddr = promContainer.NetworkConfig.EndpointsConfig[r.dockerClient.NetworkName].Gateway
 		}
 	}
 	{
@@ -122,6 +122,7 @@ func (r *Runtime) BootstrapServices(ctx context.Context) error {
 				return errors.Wrap(err, "failed to start existing pg_exporter container")
 			}
 		}
+		r.dockerHostAddr = pgExporterContainer.NetworkConfig.EndpointsConfig[r.dockerClient.NetworkName].Gateway
 	}
 	{
 		gfContainer, err = r.dockerClient.GetContainer(ctx, r.grafanaContainerName)

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -21,6 +21,12 @@ import (
 	"github.com/spinup-host/spinup/misc"
 )
 
+const (
+	pgExporterImageTag = "quay.io/prometheuscommunity/postgres-exporter:v0.11.1"
+	grafanaImageTag    = "grafana/grafana-oss:9.0.5"
+	prometheusImageTag = "bitnami/prometheus:2.38.0"
+)
+
 var (
 	defaultDatasourceCfg string
 	defaultDashboardCfg  string
@@ -170,7 +176,6 @@ func (r *Runtime) newPostgresExporterContainer(dsn string) (*dockerservice.Conta
 	endpointConfig := map[string]*network.EndpointSettings{}
 	endpointConfig[r.dockerClient.NetworkName] = &network.EndpointSettings{}
 	nwConfig := network.NetworkingConfig{EndpointsConfig: endpointConfig}
-	image := "quay.io/prometheuscommunity/postgres-exporter"
 	env := []string{
 		misc.StringToDockerEnvVal("DATA_SOURCE_NAME", dsn),
 	}
@@ -179,7 +184,7 @@ func (r *Runtime) newPostgresExporterContainer(dsn string) (*dockerservice.Conta
 	postgresExporterContainer := dockerservice.NewContainer(
 		r.pgExporterName,
 		container.Config{
-			Image: image,
+			Image: pgExporterImageTag,
 			Env:   env,
 		},
 		container.HostConfig{
@@ -199,7 +204,6 @@ func (r *Runtime) newPrometheusContainer(promCfgPath string) (*dockerservice.Con
 	endpointConfig := map[string]*network.EndpointSettings{}
 	endpointConfig[r.dockerClient.NetworkName] = &network.EndpointSettings{}
 	nwConfig := network.NetworkingConfig{EndpointsConfig: endpointConfig}
-	image := "bitnami/prometheus"
 
 	promDataDir := filepath.Join(r.appConfig.Common.ProjectDir, "prom_data")
 	err := os.Mkdir(promDataDir, 0644)
@@ -225,7 +229,7 @@ func (r *Runtime) newPrometheusContainer(promCfgPath string) (*dockerservice.Con
 	promContainer := dockerservice.NewContainer(
 		r.prometheusName,
 		container.Config{
-			Image: image,
+			Image: prometheusImageTag,
 			User:  "root",
 		},
 		container.HostConfig{
@@ -265,10 +269,9 @@ func (r *Runtime) newGrafanaContainer(datasourceDir, dashboardDir string) (*dock
 		},
 	}
 
-	image := "grafana/grafana-oss:9.0.5"
 	gfContainer := dockerservice.NewContainer(
 		r.grafanaContainerName, container.Config{
-			Image: image,
+			Image: grafanaImageTag,
 		},
 		container.HostConfig{
 			PortBindings: nat.PortMap{

--- a/internal/monitor/pg-exporter-dashboard.json
+++ b/internal/monitor/pg-exporter-dashboard.json
@@ -3504,7 +3504,13 @@
         "label": null,
         "multi": false,
         "name": "Instance",
-        "options": [],
+        "options": [
+          {
+            "selected": true,
+            "text": "<<printf \"%q\" .DefaultPgExporterInstance >>",
+            "value": "<<printf \"%q\" .DefaultPgExporterInstance >>"
+          }
+        ],
         "query": "label_values({job=\"postgres-exporter\"}, instance)",
         "refresh": 1,
         "regex": "",

--- a/internal/monitor/pg-exporter-dashboard.json
+++ b/internal/monitor/pg-exporter-dashboard.json
@@ -85,7 +85,7 @@
         "#d44a3a"
       ],
       "datasource": "DS_PROMETHEUS",
-      "description": "Source: pg_settings_server_version_num",
+      "description": "Source: server_version_num",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -626,7 +626,6 @@
         "ymax": null,
         "ymin": null
       },
-      "tableColumn": "{instance=\"db01vp-nbg6a.obs.noris.net:9187\", job=\"postgres-exporter\", server=\"213.95.132.73:5432\"}",
       "targets": [
         {
           "expr": "time()-(pg_postmaster_start_time_seconds{instance=\"$Instance\"})",
@@ -1080,7 +1079,6 @@
         "ymax": null,
         "ymin": null
       },
-      "tableColumn": "pg_settings_shared_buffers_bytes{instance=\"db01vp-nbg6a.obs.noris.net:9187\", job=\"postgres-exporter\", server=\"213.95.132.73:5432\"}",
       "targets": [
         {
           "expr": "pg_settings_shared_buffers_bytes{instance=\"$Instance\"}",
@@ -1169,7 +1167,6 @@
         "ymax": null,
         "ymin": null
       },
-      "tableColumn": "pg_settings_max_connections{instance=\"db01vp-nbg6a.obs.noris.net:9187\", job=\"postgres-exporter\", server=\"213.95.132.73:5432\"}",
       "targets": [
         {
           "expr": "pg_settings_max_connections{instance=\"$Instance\"}",
@@ -2323,7 +2320,6 @@
             "ymax": null,
             "ymin": null
           },
-          "tableColumn": "pg_stat_activity_count{datname=\"grafana\", instance=\"db01vp-nbg6a.obs.noris.net:9187\", job=\"postgres-exporter\", server=\"213.95.132.73:5432\", state=\"active\"}",
           "targets": [
             {
               "expr": "pg_stat_activity_count{state=\"active\",instance=\"$Instance\",datname=~\"$Database\"}",
@@ -2419,7 +2415,6 @@
             "ymax": null,
             "ymin": null
           },
-          "tableColumn": "pg_database_size{datname=\"grafana\", instance=\"db01vp-nbg6a.obs.noris.net:9187\", job=\"postgres-exporter\", server=\"213.95.132.73:5432\"}",
           "targets": [
             {
               "expr": "pg_database_size{instance=\"$Instance\",datname=\"$Database\"}",
@@ -3410,7 +3405,7 @@
           "linewidth": 1,
           "links": [
             {
-              "title": "PostgreSQL Ressources",
+              "title": "PostgreSQL Resources",
               "url": "https://www.postgresql.org/docs/current/runtime-config-resource.html"
             }
           ],
@@ -3514,7 +3509,7 @@
             "value": "<< .DefaultPgExporterInstance >>"
           }
         ],
-        "query": "label_values({job=\"postgres-exporter\"}, instance)",
+        "query": "label_values({job=\"pg_exporter\"}, instance)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -3567,8 +3562,8 @@
           },
           {
             "selected": false,
-            "text": "30sec",
-            "value": "30sec"
+            "text": "30s",
+            "value": "30s"
           },
           {
             "selected": false,
@@ -3592,11 +3587,6 @@
           },
           {
             "selected": false,
-            "text": "6h",
-            "value": "6h"
-          },
-          {
-            "selected": false,
             "text": "12h",
             "value": "12h"
           },
@@ -3606,7 +3596,7 @@
             "value": "1d"
           }
         ],
-        "query": "30sec,1m,10m,30m,1h,6h,12h,1d",
+        "query": "30s,1m,10m,30m,1h,6h,12h,1d",
         "queryValue": "",
         "refresh": 2,
         "skipUrlSync": false,

--- a/internal/monitor/pg-exporter-dashboard.json
+++ b/internal/monitor/pg-exporter-dashboard.json
@@ -3495,20 +3495,23 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
-        "current": {},
+        "auto": true,
+        "current": {
+          "selected": false,
+          "text": "<< .DefaultPgExporterInstance >>",
+          "value": "<< .DefaultPgExporterInstance >>"
+        },
+        "hide": 0,
+        "label": null,
+        "name": "Instance",
         "datasource": "DS_PROMETHEUS",
         "definition": "label_values({job=\"postgres-exporter\"}, instance)",
-        "hide": 0,
-        "includeAll": false,
-        "label": null,
         "multi": false,
-        "name": "Instance",
         "options": [
           {
             "selected": true,
-            "text": "<<printf \"%q\" .DefaultPgExporterInstance >>",
-            "value": "<<printf \"%q\" .DefaultPgExporterInstance >>"
+            "text": "<< .DefaultPgExporterInstance >>",
+            "value": "<< .DefaultPgExporterInstance >>"
           }
         ],
         "query": "label_values({job=\"postgres-exporter\"}, instance)",

--- a/internal/monitor/runtime.go
+++ b/internal/monitor/runtime.go
@@ -84,9 +84,9 @@ func (r *Runtime) AddTarget(ctx context.Context, t *Target) error {
 
 	var newDSN string
 	if oldDSN == "" {
-		newDSN = fmt.Sprintf("postgresql://%s:%s@%s:%s/?sslmode=disable", t.UserName, t.Password, r.dockerHostAddr, strconv.Itoa(t.Port))
+		newDSN = fmt.Sprintf("postgresql://%s:%s@%s:%s/?sslmode=disable", t.UserName, t.Password, t.ContainerName, strconv.Itoa(t.Port))
 	} else {
-		newDSN = fmt.Sprintf("%s,postgresql://%s:%s@%s:%s/?sslmode=disable", oldDSN, t.UserName, t.Password, r.dockerHostAddr, strconv.Itoa(t.Port))
+		newDSN = fmt.Sprintf("%s,postgresql://%s:%s@%s:%s/?sslmode=disable", oldDSN, t.UserName, t.Password, t.ContainerName, strconv.Itoa(t.Port))
 	}
 	newContainer, err := r.newPostgresExporterContainer(newDSN)
 	if err != nil {

--- a/internal/monitor/runtime.go
+++ b/internal/monitor/runtime.go
@@ -84,9 +84,9 @@ func (r *Runtime) AddTarget(ctx context.Context, t *Target) error {
 
 	var newDSN string
 	if oldDSN == "" {
-		newDSN = fmt.Sprintf("postgresql://%s:%s@%s:%s/?sslmode=disable", t.UserName, t.Password, t.ContainerName, strconv.Itoa(t.Port))
+		newDSN = fmt.Sprintf("postgresql://%s:%s@%s:%s/?sslmode=disable", t.UserName, t.Password, r.dockerHostAddr, strconv.Itoa(t.Port))
 	} else {
-		newDSN = fmt.Sprintf("%s,postgresql://%s:%s@%s:%s/?sslmode=disable", oldDSN, t.UserName, t.Password, t.ContainerName, strconv.Itoa(t.Port))
+		newDSN = fmt.Sprintf("%s,postgresql://%s:%s@%s:%s/?sslmode=disable", oldDSN, t.UserName, t.Password, r.dockerHostAddr, strconv.Itoa(t.Port))
 	}
 	newContainer, err := r.newPostgresExporterContainer(newDSN)
 	if err != nil {

--- a/tests/dockertest.go
+++ b/tests/dockertest.go
@@ -1,0 +1,77 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+
+	ds "github.com/spinup-host/spinup/internal/dockerservice"
+)
+
+// DockerTest wraps docker service to be used in tests
+type DockerTest struct {
+	ds.Docker
+}
+
+func NewDockerTest(ctx context.Context, networkName string) (DockerTest, error) {
+	dc, err := ds.NewDocker(networkName)
+	if err != nil {
+		return DockerTest{}, err
+	}
+
+	_, err = dc.CreateNetwork(ctx)
+	if err != nil {
+		return DockerTest{}, errors.Wrap(err, "create network")
+	}
+	return DockerTest{
+		Docker: dc,
+	}, nil
+}
+
+// Cleanup removes all containers and volumes in the docker network, and removes the network itself.
+func (dt DockerTest) Cleanup() error {
+	ctx := context.Background()
+	filter := filters.NewArgs()
+	filter.Add("network", dt.NetworkName)
+
+	containers, err := dt.Cli.ContainerList(ctx, types.ContainerListOptions{All: true, Filters: filter})
+	if err != nil {
+		return errors.Wrap(err, "list containers")
+	}
+
+	var cleanupErr error
+	for _, c := range containers {
+		stopTimeout := 1 * time.Second
+		if err = dt.Cli.ContainerStop(ctx, c.ID, &stopTimeout); err != nil {
+			if strings.Contains(err.Error(), "No such container") {
+				continue
+			}
+			cleanupErr = multierr.Append(cleanupErr, errors.Wrap(err, "stop container"))
+		}
+		if err = dt.Cli.ContainerRemove(ctx, c.ID, types.ContainerRemoveOptions{}); err != nil {
+			if strings.Contains(err.Error(), "No such container") {
+				continue
+			}
+			cleanupErr = multierr.Append(cleanupErr, errors.Wrap(err, "remove container"))
+		}
+
+		// cleanup its volumes
+		for _, mount := range c.Mounts {
+			if mount.Type == "volume" {
+				if err = dt.Cli.VolumeRemove(ctx, mount.Name, true); err != nil {
+					cleanupErr = multierr.Append(cleanupErr, errors.Wrap(err, "remove volume"))
+				}
+			}
+		}
+	}
+
+	if err = dt.Cli.NetworkRemove(ctx, dt.NetworkName); err != nil {
+		cleanupErr = multierr.Append(cleanupErr, errors.Wrap(err, "remove network"))
+	}
+	return nil
+}


### PR DESCRIPTION
The postgres exporter dashboard currently fails to load the exporter instance when viewing the dashboard. This fixes that by:
- using templates to load the IP address/port of the exporter.
- using the right prometheus job name (so other exporter instances can still be loaded and shown.