### PR TITLE
fix duplicate metrics error for multiple clusters

### DIFF
--- a/api/create.go
+++ b/api/create.go
@@ -108,13 +108,6 @@ func (c ClusterHandler) CreateService(w http.ResponseWriter, req *http.Request) 
 		}
 		return
 	}
-
-	jsonBody, err := json.Marshal(cluster)
-	if err != nil {
-		c.logger.Error("marshalling service response struct", zap.Error(err))
-		respond(http.StatusInternalServerError, w, "Internal server error")
-	} else {
-		respond(http.StatusOK, w, jsonBody)
-	}
+	respond(http.StatusOK, w, cluster)
 	return
 }

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	pgExporterImageTag = "quay.io/prometheuscommunity/postgres-exporter:v0.11.1"
+	pgExporterImageTag = "quay.io/prometheuscommunity/postgres-exporter:v0.10.1"
 	grafanaImageTag    = "grafana/grafana-oss:9.0.5"
 	prometheusImageTag = "bitnami/prometheus:2.38.0"
 )


### PR DESCRIPTION
#139 seems to be happening on the latest "stable" version of postgres_exporter (v0.11). This downgrades the docker image and also fixes an issue where we call `json.Marshal` twice on API response.

I'm still trying to investigate what caused the duplicate metrics error on new exporter version, but nothing interesting yet. 