### PR TITLE
Allow other origin for cors request

### DIFF
--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -86,7 +86,6 @@ func apiHandler() http.Handler {
 	mux.HandleFunc("/createbackup", bh.CreateBackup)
 	mux.HandleFunc("/altauth", ch.AltAuth)
 	c := cors.New(cors.Options{
-		AllowedOrigins: []string{"https://app.spinup.host", "http://localhost:3000"},
 		AllowedHeaders: []string{"authorization", "content-type", "x-api-key"},
 	})
 

--- a/scripts/install-spinup.sh
+++ b/scripts/install-spinup.sh
@@ -51,7 +51,6 @@ REACT_APP_CLIENT_ID=${CLIENT_ID}
 REACT_APP_REDIRECT_URI=http://localhost:3000/login
 REACT_APP_SERVER_URI=http://localhost:4434
 REACT_APP_GITHUB_SERVER=http://localhost:4434/githubAuth
-REACT_APP_LIST_URI=http://localhost:4434/listcluster
 REACT_APP_URL=https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=http://localhost:3000/login
 EOF
 cat .env


### PR DESCRIPTION
We currently restrict the origins that can send requests. This removes that restriction to make the deployment process easier (until we have a way of letting users configure the allowed origin list).